### PR TITLE
feat: reduce memory allocation for common slice and map types

### DIFF
--- a/ldvalue/value_array.go
+++ b/ldvalue/value_array.go
@@ -249,113 +249,126 @@ func (a ValueArray) String() string {
 	return a.JSONString()
 }
 
-func copyArbitraryArrayString(o []string) Value {
-	a := make([]Value, len(o))
-	for i, v := range o {
+func copyArbitraryArrayString(data []string) Value {
+	a := make([]Value, len(data))
+	for i, v := range data {
 		a[i] = String(v)
 	}
 
 	return Value{valueType: ArrayType, arrayValue: ValueArray{data: a}}
 }
-func copyArbitraryArrayBool(o []bool) Value {
-	a := make([]Value, len(o))
-	for i, v := range o {
+
+func copyArbitraryArrayBool(data []bool) Value {
+	a := make([]Value, len(data))
+	for i, v := range data {
 		a[i] = Bool(v)
 	}
 
 	return Value{valueType: ArrayType, arrayValue: ValueArray{data: a}}
 }
-func copyArbitraryArrayInt(o []int) Value {
-	a := make([]Value, len(o))
-	for i, v := range o {
+
+func copyArbitraryArrayInt(data []int) Value {
+	a := make([]Value, len(data))
+	for i, v := range data {
 		a[i] = Float64(float64(v))
 	}
 
 	return Value{valueType: ArrayType, arrayValue: ValueArray{data: a}}
 }
-func copyArbitraryArrayInt8(o []int8) Value {
-	a := make([]Value, len(o))
-	for i, v := range o {
+
+func copyArbitraryArrayInt8(data []int8) Value {
+	a := make([]Value, len(data))
+	for i, v := range data {
 		a[i] = Float64(float64(v))
 	}
 
 	return Value{valueType: ArrayType, arrayValue: ValueArray{data: a}}
 }
-func copyArbitraryArrayInt16(o []int16) Value {
-	a := make([]Value, len(o))
-	for i, v := range o {
+
+func copyArbitraryArrayInt16(data []int16) Value {
+	a := make([]Value, len(data))
+	for i, v := range data {
 		a[i] = Float64(float64(v))
 	}
 
 	return Value{valueType: ArrayType, arrayValue: ValueArray{data: a}}
 }
-func copyArbitraryArrayInt32(o []int32) Value {
-	a := make([]Value, len(o))
-	for i, v := range o {
+
+func copyArbitraryArrayInt32(data []int32) Value {
+	a := make([]Value, len(data))
+	for i, v := range data {
 		a[i] = Float64(float64(v))
 	}
 
 	return Value{valueType: ArrayType, arrayValue: ValueArray{data: a}}
 }
-func copyArbitraryArrayInt64(o []int64) Value {
-	a := make([]Value, len(o))
-	for i, v := range o {
+
+func copyArbitraryArrayInt64(data []int64) Value {
+	a := make([]Value, len(data))
+	for i, v := range data {
 		a[i] = Float64(float64(v))
 	}
 
 	return Value{valueType: ArrayType, arrayValue: ValueArray{data: a}}
 }
-func copyArbitraryArrayUint(o []uint) Value {
-	a := make([]Value, len(o))
-	for i, v := range o {
+
+func copyArbitraryArrayUint(data []uint) Value {
+	a := make([]Value, len(data))
+	for i, v := range data {
 		a[i] = Float64(float64(v))
 	}
 
 	return Value{valueType: ArrayType, arrayValue: ValueArray{data: a}}
 }
-func copyArbitraryArrayUint8(o []uint8) Value {
-	a := make([]Value, len(o))
-	for i, v := range o {
+
+func copyArbitraryArrayUint8(data []uint8) Value {
+	a := make([]Value, len(data))
+	for i, v := range data {
 		a[i] = Float64(float64(v))
 	}
 
 	return Value{valueType: ArrayType, arrayValue: ValueArray{data: a}}
 }
-func copyArbitraryArrayUint16(o []uint16) Value {
-	a := make([]Value, len(o))
-	for i, v := range o {
+
+func copyArbitraryArrayUint16(data []uint16) Value {
+	a := make([]Value, len(data))
+	for i, v := range data {
 		a[i] = Float64(float64(v))
 	}
 
 	return Value{valueType: ArrayType, arrayValue: ValueArray{data: a}}
 }
-func copyArbitraryArrayUint32(o []uint32) Value {
-	a := make([]Value, len(o))
-	for i, v := range o {
+
+func copyArbitraryArrayUint32(data []uint32) Value {
+	a := make([]Value, len(data))
+	for i, v := range data {
 		a[i] = Float64(float64(v))
 	}
 
 	return Value{valueType: ArrayType, arrayValue: ValueArray{data: a}}
 }
-func copyArbitraryArrayUint64(o []uint64) Value {
-	a := make([]Value, len(o))
-	for i, v := range o {
+
+func copyArbitraryArrayUint64(data []uint64) Value {
+	a := make([]Value, len(data))
+	for i, v := range data {
 		a[i] = Float64(float64(v))
 	}
 
 	return Value{valueType: ArrayType, arrayValue: ValueArray{data: a}}
 }
-func copyArbitraryArrayFloat32(o []float32) Value {
-	a := make([]Value, len(o))
-	for i, v := range o {
+
+func copyArbitraryArrayFloat32(data []float32) Value {
+	a := make([]Value, len(data))
+	for i, v := range data {
 		a[i] = Float64(float64(v))
 	}
 
 	return Value{valueType: ArrayType, arrayValue: ValueArray{data: a}}
 }
-func copyArbitraryArrayFloat64(o []float64) Value {
-	a := make([]Value, len(o))
-	for i, v := range o {
+
+func copyArbitraryArrayFloat64(data []float64) Value {
+	a := make([]Value, len(data))
+	for i, v := range data {
 		a[i] = Float64(v)
 	}
 

--- a/ldvalue/value_array.go
+++ b/ldvalue/value_array.go
@@ -248,3 +248,116 @@ func (a ValueArray) Transform(fn func(index int, value Value) (Value, bool)) Val
 func (a ValueArray) String() string {
 	return a.JSONString()
 }
+
+func copyArbitraryArrayString(o []string) Value {
+	a := make([]Value, len(o))
+	for i, v := range o {
+		a[i] = String(v)
+	}
+
+	return Value{valueType: ArrayType, arrayValue: ValueArray{data: a}}
+}
+func copyArbitraryArrayBool(o []bool) Value {
+	a := make([]Value, len(o))
+	for i, v := range o {
+		a[i] = Bool(v)
+	}
+
+	return Value{valueType: ArrayType, arrayValue: ValueArray{data: a}}
+}
+func copyArbitraryArrayInt(o []int) Value {
+	a := make([]Value, len(o))
+	for i, v := range o {
+		a[i] = Float64(float64(v))
+	}
+
+	return Value{valueType: ArrayType, arrayValue: ValueArray{data: a}}
+}
+func copyArbitraryArrayInt8(o []int8) Value {
+	a := make([]Value, len(o))
+	for i, v := range o {
+		a[i] = Float64(float64(v))
+	}
+
+	return Value{valueType: ArrayType, arrayValue: ValueArray{data: a}}
+}
+func copyArbitraryArrayInt16(o []int16) Value {
+	a := make([]Value, len(o))
+	for i, v := range o {
+		a[i] = Float64(float64(v))
+	}
+
+	return Value{valueType: ArrayType, arrayValue: ValueArray{data: a}}
+}
+func copyArbitraryArrayInt32(o []int32) Value {
+	a := make([]Value, len(o))
+	for i, v := range o {
+		a[i] = Float64(float64(v))
+	}
+
+	return Value{valueType: ArrayType, arrayValue: ValueArray{data: a}}
+}
+func copyArbitraryArrayInt64(o []int64) Value {
+	a := make([]Value, len(o))
+	for i, v := range o {
+		a[i] = Float64(float64(v))
+	}
+
+	return Value{valueType: ArrayType, arrayValue: ValueArray{data: a}}
+}
+func copyArbitraryArrayUint(o []uint) Value {
+	a := make([]Value, len(o))
+	for i, v := range o {
+		a[i] = Float64(float64(v))
+	}
+
+	return Value{valueType: ArrayType, arrayValue: ValueArray{data: a}}
+}
+func copyArbitraryArrayUint8(o []uint8) Value {
+	a := make([]Value, len(o))
+	for i, v := range o {
+		a[i] = Float64(float64(v))
+	}
+
+	return Value{valueType: ArrayType, arrayValue: ValueArray{data: a}}
+}
+func copyArbitraryArrayUint16(o []uint16) Value {
+	a := make([]Value, len(o))
+	for i, v := range o {
+		a[i] = Float64(float64(v))
+	}
+
+	return Value{valueType: ArrayType, arrayValue: ValueArray{data: a}}
+}
+func copyArbitraryArrayUint32(o []uint32) Value {
+	a := make([]Value, len(o))
+	for i, v := range o {
+		a[i] = Float64(float64(v))
+	}
+
+	return Value{valueType: ArrayType, arrayValue: ValueArray{data: a}}
+}
+func copyArbitraryArrayUint64(o []uint64) Value {
+	a := make([]Value, len(o))
+	for i, v := range o {
+		a[i] = Float64(float64(v))
+	}
+
+	return Value{valueType: ArrayType, arrayValue: ValueArray{data: a}}
+}
+func copyArbitraryArrayFloat32(o []float32) Value {
+	a := make([]Value, len(o))
+	for i, v := range o {
+		a[i] = Float64(float64(v))
+	}
+
+	return Value{valueType: ArrayType, arrayValue: ValueArray{data: a}}
+}
+func copyArbitraryArrayFloat64(o []float64) Value {
+	a := make([]Value, len(o))
+	for i, v := range o {
+		a[i] = Float64(v)
+	}
+
+	return Value{valueType: ArrayType, arrayValue: ValueArray{data: a}}
+}

--- a/ldvalue/value_array_test.go
+++ b/ldvalue/value_array_test.go
@@ -255,6 +255,87 @@ func TestValueArrayTransform(t *testing.T) {
 	assert.Equal(t, ValueArrayOf(), ValueArrayOf().Transform(shouldNotCallThis))
 }
 
+func TestCopyArbitrarySliceOfType(t *testing.T) {
+	var sNil []string
+	vm := CopyArbitraryValue(sNil)
+	assert.Equal(t, ArrayType, vm.Type())
+
+	sEmpty := []string{}
+	vm = CopyArbitraryValue(sEmpty)
+	assert.Equal(t, ArrayType, vm.Type())
+	assert.Equal(t, []Value{}, vm.arrayValue.data)
+
+	sStr := []string{"a", "b", "c"}
+	vm = CopyArbitraryValue(sStr)
+	assert.Equal(t, ArrayType, vm.Type())
+	assert.Equal(t, []Value{String("a"), String("b"), String("c")}, vm.arrayValue.data)
+
+	sBool := []bool{true, false}
+	vm = CopyArbitraryValue(sBool)
+	assert.Equal(t, ArrayType, vm.Type())
+	assert.Equal(t, []Value{Bool(true), Bool(false)}, vm.arrayValue.data)
+
+	sInt := []int{1, 2, 3}
+	vm = CopyArbitraryValue(sInt)
+	assert.Equal(t, ArrayType, vm.Type())
+	assert.Equal(t, []Value{Int(1), Int(2), Int(3)}, vm.arrayValue.data)
+
+	sInt8 := []int8{1, 2, 3}
+	vm = CopyArbitraryValue(sInt8)
+	assert.Equal(t, ArrayType, vm.Type())
+	assert.Equal(t, []Value{Int(1), Int(2), Int(3)}, vm.arrayValue.data)
+
+	sInt16 := []int16{1, 2, 3}
+	vm = CopyArbitraryValue(sInt16)
+	assert.Equal(t, ArrayType, vm.Type())
+	assert.Equal(t, []Value{Int(1), Int(2), Int(3)}, vm.arrayValue.data)
+
+	sInt32 := []int32{1, 2, 3}
+	vm = CopyArbitraryValue(sInt32)
+	assert.Equal(t, ArrayType, vm.Type())
+	assert.Equal(t, []Value{Int(1), Int(2), Int(3)}, vm.arrayValue.data)
+
+	sInt64 := []int64{1, 2, 3}
+	vm = CopyArbitraryValue(sInt64)
+	assert.Equal(t, ArrayType, vm.Type())
+	assert.Equal(t, []Value{Int(1), Int(2), Int(3)}, vm.arrayValue.data)
+
+	sUint := []uint{1, 2, 3}
+	vm = CopyArbitraryValue(sUint)
+	assert.Equal(t, ArrayType, vm.Type())
+	assert.Equal(t, []Value{Int(1), Int(2), Int(3)}, vm.arrayValue.data)
+
+	sUint8 := []uint8{1, 2, 3}
+	vm = CopyArbitraryValue(sUint8)
+	assert.Equal(t, ArrayType, vm.Type())
+	assert.Equal(t, []Value{Int(1), Int(2), Int(3)}, vm.arrayValue.data)
+
+	sUint16 := []uint16{1, 2, 3}
+	vm = CopyArbitraryValue(sUint16)
+	assert.Equal(t, ArrayType, vm.Type())
+	assert.Equal(t, []Value{Int(1), Int(2), Int(3)}, vm.arrayValue.data)
+
+	sUint32 := []uint32{1, 2, 3}
+	vm = CopyArbitraryValue(sUint32)
+	assert.Equal(t, ArrayType, vm.Type())
+	assert.Equal(t, []Value{Int(1), Int(2), Int(3)}, vm.arrayValue.data)
+
+	sUint64 := []uint64{1, 2, 3}
+	vm = CopyArbitraryValue(sUint64)
+	assert.Equal(t, ArrayType, vm.Type())
+	assert.Equal(t, []Value{Int(1), Int(2), Int(3)}, vm.arrayValue.data)
+
+	sFloat32 := []float32{1.0, 2.0, 3.0}
+	vm = CopyArbitraryValue(sFloat32)
+	assert.Equal(t, ArrayType, vm.Type())
+	assert.Equal(t, []Value{Float64(1.0), Float64(2.0), Float64(3.0)}, vm.arrayValue.data)
+
+	sFloat64 := []float64{1.1, 2.2, 3.3}
+	vm = CopyArbitraryValue(sFloat64)
+	assert.Equal(t, ArrayType, vm.Type())
+	assert.Equal(t, []Value{Float64(1.1), Float64(2.2), Float64(3.3)}, vm.arrayValue.data)
+}
+
 func shouldBeSameSlice(t *testing.T, s0 []Value, s1 []Value) {
 	old := s0[0]
 	s0[0] = String("temp-value")

--- a/ldvalue/value_base.go
+++ b/ldvalue/value_base.go
@@ -296,6 +296,34 @@ func CopyArbitraryValue(anyValue any) Value { //nolint:gocyclo // yes, we know i
 			return Null()
 		}
 		return ArrayOf((*o)...)
+	case []string:
+		return copyArbitraryArrayString(o)
+	case []bool:
+		return copyArbitraryArrayBool(o)
+	case []int:
+		return copyArbitraryArrayInt(o)
+	case []int8:
+		return copyArbitraryArrayInt8(o)
+	case []int16:
+		return copyArbitraryArrayInt16(o)
+	case []int32:
+		return copyArbitraryArrayInt32(o)
+	case []int64:
+		return copyArbitraryArrayInt64(o)
+	case []uint:
+		return copyArbitraryArrayUint(o)
+	case []uint8:
+		return copyArbitraryArrayUint8(o)
+	case []uint16:
+		return copyArbitraryArrayUint16(o)
+	case []uint32:
+		return copyArbitraryArrayUint32(o)
+	case []uint64:
+		return copyArbitraryArrayUint64(o)
+	case []float32:
+		return copyArbitraryArrayFloat32(o)
+	case []float64:
+		return copyArbitraryArrayFloat64(o)
 	case map[string]any:
 		return copyArbitraryValueMap(o)
 	case *map[string]any:
@@ -310,6 +338,34 @@ func CopyArbitraryValue(anyValue any) Value { //nolint:gocyclo // yes, we know i
 			return Null()
 		}
 		return CopyObject(*o)
+	case map[string]string:
+		return copyArbitraryMapString(o)
+	case map[string]bool:
+		return copyArbitraryMapBool(o)
+	case map[string]int:
+		return copyArbitraryMapInt(o)
+	case map[string]int8:
+		return copyArbitraryMapInt8(o)
+	case map[string]int16:
+		return copyArbitraryMapInt16(o)
+	case map[string]int32:
+		return copyArbitraryMapInt32(o)
+	case map[string]int64:
+		return copyArbitraryMapInt64(o)
+	case map[string]uint:
+		return copyArbitraryMapUint(o)
+	case map[string]uint8:
+		return copyArbitraryMapUint8(o)
+	case map[string]uint16:
+		return copyArbitraryMapUint16(o)
+	case map[string]uint32:
+		return copyArbitraryMapUint32(o)
+	case map[string]uint64:
+		return copyArbitraryMapUint64(o)
+	case map[string]float32:
+		return copyArbitraryMapFloat32(o)
+	case map[string]float64:
+		return copyArbitraryMapFloat64(o)
 	case json.RawMessage:
 		return Raw(o)
 	case *json.RawMessage:

--- a/ldvalue/value_collection_benchmark_test.go
+++ b/ldvalue/value_collection_benchmark_test.go
@@ -1,0 +1,111 @@
+package ldvalue
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func BenchmarkReflectCopyMapStringSmall(b *testing.B) {
+	input := generateRandomMap(10)
+
+	for i := 0; i < b.N; i++ {
+		_ = CopyArbitraryValue(input)
+	}
+}
+
+func BenchmarkReflectCopyMapStringLarge(b *testing.B) {
+	input := generateRandomMap(1_000)
+
+	for i := 0; i < b.N; i++ {
+		_ = CopyArbitraryValue(input)
+	}
+}
+
+func generateRandomMap(i int) map[string]string {
+	m := make(map[string]string, i)
+
+	for j := 0; j < i; j++ {
+		m[generateRandomString()] = generateRandomString()
+	}
+
+	return m
+}
+
+func BenchmarkReflectCopySliceStringSmall(b *testing.B) {
+	input := generateStringSlice(10)
+
+	for i := 0; i < b.N; i++ {
+		_ = CopyArbitraryValue(input)
+	}
+}
+
+func BenchmarkReflectCopySliceStringMedium(b *testing.B) {
+	input := generateStringSlice(100)
+
+	for i := 0; i < b.N; i++ {
+		_ = CopyArbitraryValue(input)
+	}
+}
+
+func BenchmarkReflectCopySliceStringLarge(b *testing.B) {
+	input := generateStringSlice(1_000)
+
+	for i := 0; i < b.N; i++ {
+		_ = CopyArbitraryValue(input)
+	}
+}
+
+func BenchmarkReflectCopySliceIntSmall(b *testing.B) {
+	input := generateIntSlice(10)
+
+	for i := 0; i < b.N; i++ {
+		_ = CopyArbitraryValue(input)
+	}
+}
+
+func BenchmarkReflectCopySliceIntMedium(b *testing.B) {
+	input := generateIntSlice(100)
+
+	for i := 0; i < b.N; i++ {
+		_ = CopyArbitraryValue(input)
+	}
+}
+
+func BenchmarkReflectCopySliceIntLarge(b *testing.B) {
+	input := generateIntSlice(1_000)
+
+	for i := 0; i < b.N; i++ {
+		_ = CopyArbitraryValue(input)
+	}
+}
+
+func generateIntSlice(n int) []int {
+	s := make([]int, n)
+
+	for i := 0; i < n; i++ {
+		s[i] = rand.Int()
+	}
+
+	return s
+}
+
+func generateStringSlice(n int) []string {
+	s := make([]string, n)
+
+	for i := 0; i < n; i++ {
+		s[i] = generateRandomString()
+	}
+
+	return s
+}
+
+func generateRandomString() string {
+	alpha := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+	b := make([]byte, 10)
+	for i := range b {
+		b[i] = alpha[rand.Intn(len(alpha))]
+	}
+
+	return string(b)
+}

--- a/ldvalue/value_collection_benchmark_test.go
+++ b/ldvalue/value_collection_benchmark_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func BenchmarkReflectCopyMapStringSmall(b *testing.B) {
+func BenchmarkCollectionCopyMapStringSmall(b *testing.B) {
 	input := generateRandomMap(10)
 
 	for i := 0; i < b.N; i++ {
@@ -13,7 +13,7 @@ func BenchmarkReflectCopyMapStringSmall(b *testing.B) {
 	}
 }
 
-func BenchmarkReflectCopyMapStringLarge(b *testing.B) {
+func BenchmarkCollectionCopyMapStringLarge(b *testing.B) {
 	input := generateRandomMap(1_000)
 
 	for i := 0; i < b.N; i++ {
@@ -31,7 +31,7 @@ func generateRandomMap(i int) map[string]string {
 	return m
 }
 
-func BenchmarkReflectCopySliceStringSmall(b *testing.B) {
+func BenchmarkCollectionCopySliceStringSmall(b *testing.B) {
 	input := generateStringSlice(10)
 
 	for i := 0; i < b.N; i++ {
@@ -39,7 +39,7 @@ func BenchmarkReflectCopySliceStringSmall(b *testing.B) {
 	}
 }
 
-func BenchmarkReflectCopySliceStringMedium(b *testing.B) {
+func BenchmarkCollectionCopySliceStringMedium(b *testing.B) {
 	input := generateStringSlice(100)
 
 	for i := 0; i < b.N; i++ {
@@ -47,7 +47,7 @@ func BenchmarkReflectCopySliceStringMedium(b *testing.B) {
 	}
 }
 
-func BenchmarkReflectCopySliceStringLarge(b *testing.B) {
+func BenchmarkCollectionCopySliceStringLarge(b *testing.B) {
 	input := generateStringSlice(1_000)
 
 	for i := 0; i < b.N; i++ {
@@ -55,7 +55,7 @@ func BenchmarkReflectCopySliceStringLarge(b *testing.B) {
 	}
 }
 
-func BenchmarkReflectCopySliceIntSmall(b *testing.B) {
+func BenchmarkCollectionCopySliceIntSmall(b *testing.B) {
 	input := generateIntSlice(10)
 
 	for i := 0; i < b.N; i++ {
@@ -63,7 +63,7 @@ func BenchmarkReflectCopySliceIntSmall(b *testing.B) {
 	}
 }
 
-func BenchmarkReflectCopySliceIntMedium(b *testing.B) {
+func BenchmarkCollectionCopySliceIntMedium(b *testing.B) {
 	input := generateIntSlice(100)
 
 	for i := 0; i < b.N; i++ {
@@ -71,7 +71,7 @@ func BenchmarkReflectCopySliceIntMedium(b *testing.B) {
 	}
 }
 
-func BenchmarkReflectCopySliceIntLarge(b *testing.B) {
+func BenchmarkCollectionCopySliceIntLarge(b *testing.B) {
 	input := generateIntSlice(1_000)
 
 	for i := 0; i < b.N; i++ {

--- a/ldvalue/value_map.go
+++ b/ldvalue/value_map.go
@@ -268,3 +268,115 @@ func (m ValueMap) Transform(fn func(key string, value Value) (string, Value, boo
 	}
 	return ValueMap{ret}
 }
+
+func copyArbitraryMapString(data map[string]string) Value {
+	m := make(map[string]Value, len(data))
+	for k, v := range data {
+		m[k] = String(v)
+	}
+	return Value{valueType: ObjectType, objectValue: ValueMap{data: m}}
+}
+
+func copyArbitraryMapBool(data map[string]bool) Value {
+	m := make(map[string]Value, len(data))
+	for k, v := range data {
+		m[k] = Bool(v)
+	}
+	return Value{valueType: ObjectType, objectValue: ValueMap{data: m}}
+}
+
+func copyArbitraryMapInt(data map[string]int) Value {
+	m := make(map[string]Value, len(data))
+	for k, v := range data {
+		m[k] = Float64(float64(v))
+	}
+	return Value{valueType: ObjectType, objectValue: ValueMap{data: m}}
+}
+
+func copyArbitraryMapInt8(data map[string]int8) Value {
+	m := make(map[string]Value, len(data))
+	for k, v := range data {
+		m[k] = Float64(float64(v))
+	}
+	return Value{valueType: ObjectType, objectValue: ValueMap{data: m}}
+}
+
+func copyArbitraryMapInt16(data map[string]int16) Value {
+	m := make(map[string]Value, len(data))
+	for k, v := range data {
+		m[k] = Float64(float64(v))
+	}
+	return Value{valueType: ObjectType, objectValue: ValueMap{data: m}}
+}
+
+func copyArbitraryMapInt32(data map[string]int32) Value {
+	m := make(map[string]Value, len(data))
+	for k, v := range data {
+		m[k] = Float64(float64(v))
+	}
+	return Value{valueType: ObjectType, objectValue: ValueMap{data: m}}
+}
+
+func copyArbitraryMapInt64(data map[string]int64) Value {
+	m := make(map[string]Value, len(data))
+	for k, v := range data {
+		m[k] = Float64(float64(v))
+	}
+	return Value{valueType: ObjectType, objectValue: ValueMap{data: m}}
+}
+
+func copyArbitraryMapUint(data map[string]uint) Value {
+	m := make(map[string]Value, len(data))
+	for k, v := range data {
+		m[k] = Float64(float64(v))
+	}
+	return Value{valueType: ObjectType, objectValue: ValueMap{data: m}}
+}
+
+func copyArbitraryMapUint8(data map[string]uint8) Value {
+	m := make(map[string]Value, len(data))
+	for k, v := range data {
+		m[k] = Float64(float64(v))
+	}
+	return Value{valueType: ObjectType, objectValue: ValueMap{data: m}}
+}
+
+func copyArbitraryMapUint16(data map[string]uint16) Value {
+	m := make(map[string]Value, len(data))
+	for k, v := range data {
+		m[k] = Float64(float64(v))
+	}
+	return Value{valueType: ObjectType, objectValue: ValueMap{data: m}}
+}
+
+func copyArbitraryMapUint32(data map[string]uint32) Value {
+	m := make(map[string]Value, len(data))
+	for k, v := range data {
+		m[k] = Float64(float64(v))
+	}
+	return Value{valueType: ObjectType, objectValue: ValueMap{data: m}}
+}
+
+func copyArbitraryMapUint64(data map[string]uint64) Value {
+	m := make(map[string]Value, len(data))
+	for k, v := range data {
+		m[k] = Float64(float64(v))
+	}
+	return Value{valueType: ObjectType, objectValue: ValueMap{data: m}}
+}
+
+func copyArbitraryMapFloat32(data map[string]float32) Value {
+	m := make(map[string]Value, len(data))
+	for k, v := range data {
+		m[k] = Float64(float64(v))
+	}
+	return Value{valueType: ObjectType, objectValue: ValueMap{data: m}}
+}
+
+func copyArbitraryMapFloat64(data map[string]float64) Value {
+	m := make(map[string]Value, len(data))
+	for k, v := range data {
+		m[k] = Float64(float64(v))
+	}
+	return Value{valueType: ObjectType, objectValue: ValueMap{data: m}}
+}

--- a/ldvalue/value_map.go
+++ b/ldvalue/value_map.go
@@ -274,6 +274,7 @@ func copyArbitraryMapString(data map[string]string) Value {
 	for k, v := range data {
 		m[k] = String(v)
 	}
+
 	return Value{valueType: ObjectType, objectValue: ValueMap{data: m}}
 }
 
@@ -282,6 +283,7 @@ func copyArbitraryMapBool(data map[string]bool) Value {
 	for k, v := range data {
 		m[k] = Bool(v)
 	}
+
 	return Value{valueType: ObjectType, objectValue: ValueMap{data: m}}
 }
 
@@ -290,6 +292,7 @@ func copyArbitraryMapInt(data map[string]int) Value {
 	for k, v := range data {
 		m[k] = Float64(float64(v))
 	}
+
 	return Value{valueType: ObjectType, objectValue: ValueMap{data: m}}
 }
 
@@ -298,6 +301,7 @@ func copyArbitraryMapInt8(data map[string]int8) Value {
 	for k, v := range data {
 		m[k] = Float64(float64(v))
 	}
+
 	return Value{valueType: ObjectType, objectValue: ValueMap{data: m}}
 }
 
@@ -306,6 +310,7 @@ func copyArbitraryMapInt16(data map[string]int16) Value {
 	for k, v := range data {
 		m[k] = Float64(float64(v))
 	}
+
 	return Value{valueType: ObjectType, objectValue: ValueMap{data: m}}
 }
 
@@ -314,6 +319,7 @@ func copyArbitraryMapInt32(data map[string]int32) Value {
 	for k, v := range data {
 		m[k] = Float64(float64(v))
 	}
+
 	return Value{valueType: ObjectType, objectValue: ValueMap{data: m}}
 }
 
@@ -322,6 +328,7 @@ func copyArbitraryMapInt64(data map[string]int64) Value {
 	for k, v := range data {
 		m[k] = Float64(float64(v))
 	}
+
 	return Value{valueType: ObjectType, objectValue: ValueMap{data: m}}
 }
 
@@ -330,6 +337,7 @@ func copyArbitraryMapUint(data map[string]uint) Value {
 	for k, v := range data {
 		m[k] = Float64(float64(v))
 	}
+
 	return Value{valueType: ObjectType, objectValue: ValueMap{data: m}}
 }
 
@@ -338,6 +346,7 @@ func copyArbitraryMapUint8(data map[string]uint8) Value {
 	for k, v := range data {
 		m[k] = Float64(float64(v))
 	}
+
 	return Value{valueType: ObjectType, objectValue: ValueMap{data: m}}
 }
 
@@ -346,6 +355,7 @@ func copyArbitraryMapUint16(data map[string]uint16) Value {
 	for k, v := range data {
 		m[k] = Float64(float64(v))
 	}
+
 	return Value{valueType: ObjectType, objectValue: ValueMap{data: m}}
 }
 
@@ -354,6 +364,7 @@ func copyArbitraryMapUint32(data map[string]uint32) Value {
 	for k, v := range data {
 		m[k] = Float64(float64(v))
 	}
+
 	return Value{valueType: ObjectType, objectValue: ValueMap{data: m}}
 }
 
@@ -362,6 +373,7 @@ func copyArbitraryMapUint64(data map[string]uint64) Value {
 	for k, v := range data {
 		m[k] = Float64(float64(v))
 	}
+
 	return Value{valueType: ObjectType, objectValue: ValueMap{data: m}}
 }
 
@@ -370,13 +382,15 @@ func copyArbitraryMapFloat32(data map[string]float32) Value {
 	for k, v := range data {
 		m[k] = Float64(float64(v))
 	}
+
 	return Value{valueType: ObjectType, objectValue: ValueMap{data: m}}
 }
 
 func copyArbitraryMapFloat64(data map[string]float64) Value {
 	m := make(map[string]Value, len(data))
 	for k, v := range data {
-		m[k] = Float64(float64(v))
+		m[k] = Float64(v)
 	}
+
 	return Value{valueType: ObjectType, objectValue: ValueMap{data: m}}
 }

--- a/ldvalue/value_map_test.go
+++ b/ldvalue/value_map_test.go
@@ -315,3 +315,84 @@ func shouldNotBeSameMap(t *testing.T, m0 map[string]Value, m1 map[string]Value) 
 	assert.NotEqual(t, m0, m1, "ValueMaps should not be sharing same map but they are")
 	delete(m0, "temp-property")
 }
+
+func TestCopyArbitraryMapOfType(t *testing.T) {
+	var mNil map[string]string
+	vm := CopyArbitraryValue(mNil)
+	assert.Equal(t, ObjectType, vm.Type())
+
+	mEmpty := map[string]string{}
+	vm = CopyArbitraryValue(mEmpty)
+	assert.Equal(t, ObjectType, vm.Type())
+	assert.Equal(t, map[string]Value{}, vm.objectValue.data)
+
+	mStr := map[string]string{"a": "1", "b": "2", "c": "3"}
+	vm = CopyArbitraryValue(mStr)
+	assert.Equal(t, ObjectType, vm.Type())
+	assert.Equal(t, map[string]Value{"a": String("1"), "b": String("2"), "c": String("3")}, vm.objectValue.data)
+
+	mBool := map[string]bool{"a": true, "b": false, "c": true}
+	vm = CopyArbitraryValue(mBool)
+	assert.Equal(t, ObjectType, vm.Type())
+	assert.Equal(t, map[string]Value{"a": Bool(true), "b": Bool(false), "c": Bool(true)}, vm.objectValue.data)
+
+	mInt := map[string]int{"a": 1, "b": 2, "c": 3}
+	vm = CopyArbitraryValue(mInt)
+	assert.Equal(t, ObjectType, vm.Type())
+	assert.Equal(t, map[string]Value{"a": Int(1), "b": Int(2), "c": Int(3)}, vm.objectValue.data)
+
+	mInt8 := map[string]int8{"a": 1, "b": 2, "c": 3}
+	vm = CopyArbitraryValue(mInt8)
+	assert.Equal(t, ObjectType, vm.Type())
+	assert.Equal(t, map[string]Value{"a": Int(1), "b": Int(2), "c": Int(3)}, vm.objectValue.data)
+
+	mInt16 := map[string]int16{"a": 1, "b": 2, "c": 3}
+	vm = CopyArbitraryValue(mInt16)
+	assert.Equal(t, ObjectType, vm.Type())
+	assert.Equal(t, map[string]Value{"a": Int(1), "b": Int(2), "c": Int(3)}, vm.objectValue.data)
+
+	mInt32 := map[string]int32{"a": 1, "b": 2, "c": 3}
+	vm = CopyArbitraryValue(mInt32)
+	assert.Equal(t, ObjectType, vm.Type())
+	assert.Equal(t, map[string]Value{"a": Int(1), "b": Int(2), "c": Int(3)}, vm.objectValue.data)
+
+	mInt64 := map[string]int64{"a": 1, "b": 2, "c": 3}
+	vm = CopyArbitraryValue(mInt64)
+	assert.Equal(t, ObjectType, vm.Type())
+	assert.Equal(t, map[string]Value{"a": Int(1), "b": Int(2), "c": Int(3)}, vm.objectValue.data)
+
+	mUint := map[string]uint{"a": 1, "b": 2, "c": 3}
+	vm = CopyArbitraryValue(mUint)
+	assert.Equal(t, ObjectType, vm.Type())
+	assert.Equal(t, map[string]Value{"a": Int(1), "b": Int(2), "c": Int(3)}, vm.objectValue.data)
+
+	mUint8 := map[string]uint8{"a": 1, "b": 2, "c": 3}
+	vm = CopyArbitraryValue(mUint8)
+	assert.Equal(t, ObjectType, vm.Type())
+	assert.Equal(t, map[string]Value{"a": Int(1), "b": Int(2), "c": Int(3)}, vm.objectValue.data)
+
+	mUint16 := map[string]uint16{"a": 1, "b": 2, "c": 3}
+	vm = CopyArbitraryValue(mUint16)
+	assert.Equal(t, ObjectType, vm.Type())
+	assert.Equal(t, map[string]Value{"a": Int(1), "b": Int(2), "c": Int(3)}, vm.objectValue.data)
+
+	mUint32 := map[string]uint32{"a": 1, "b": 2, "c": 3}
+	vm = CopyArbitraryValue(mUint32)
+	assert.Equal(t, ObjectType, vm.Type())
+	assert.Equal(t, map[string]Value{"a": Int(1), "b": Int(2), "c": Int(3)}, vm.objectValue.data)
+
+	mUint64 := map[string]uint64{"a": 1, "b": 2, "c": 3}
+	vm = CopyArbitraryValue(mUint64)
+	assert.Equal(t, ObjectType, vm.Type())
+	assert.Equal(t, map[string]Value{"a": Int(1), "b": Int(2), "c": Int(3)}, vm.objectValue.data)
+
+	mFloat32 := map[string]float32{"a": 1.0, "b": 2.0, "c": 3.0}
+	vm = CopyArbitraryValue(mFloat32)
+	assert.Equal(t, ObjectType, vm.Type())
+	assert.Equal(t, map[string]Value{"a": Float64(1.0), "b": Float64(2.0), "c": Float64(3.0)}, vm.objectValue.data)
+
+	mFloat64 := map[string]float64{"a": 1.1, "b": 2.2, "c": 3.3}
+	vm = CopyArbitraryValue(mFloat64)
+	assert.Equal(t, ObjectType, vm.Type())
+	assert.Equal(t, map[string]Value{"a": Float64(1.1), "b": Float64(2.2), "c": Float64(3.3)}, vm.objectValue.data)
+}


### PR DESCRIPTION
**Requirements**

- [X] I have added test coverage for new or changed functionality
- [X] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions


**Describe the solution you've provided**

Reduce memory allocations for some collection types by avoiding the slow and expensive JSON marshal->unmarshal path.  Extend the list of type assertions to slices and maps of some primitive types. 

**Additional context**

While memory profiling a production application we noticed that 50+% of our memory allocations were happening during `ldvalue.CopyArbitraryValue`.  We use feature flags heavily, and for any HTTP request it is typical to evaluate 2-8 feature flags. We found that the reason for this high memory usage was due to a string slice with several hundred items being passed through `ldvalue.CopyArbitraryValue` on most `ldcontext.Builder` instantiations.  This was occurring in a general use function like 

```
func IsEnabled(ctx context.Context, flag string, attributes map[string]any) bool {
  client := ctx.Value("ld-client).(*ldclient.LDClient)
  
  builder := ldcontextBuilderFromCtx(ctx) // get some HTTP request type info, user info, etc. 
  
  // note ldvalue.CopyArbitraryValueMap has the same issue 
  for key, value := range attributes {
    builder.SetValue(key, ldvalue.CopyArbitraryValue(value))
  }
  
  // ignore errors for ex. 
  enabled, _ := client.BoolVariation(flag, builder.Build(), false)

  return enabled 
}
```

If any of the `map[string]any` values are themselves a `[]string` or similar we hit the `FromJSONMarshal` slow path. To partially solve the problem we have written a wrapper around this SDK with more or less the same code as I am submitting here.  The reduction in memory allocation is especially noticeable when copying `[]string`, but in all cases there is a fairly significant improvement in latency and total memory usage. 

Although this is verbose, alternatives that use generic functions like 
```
func copyArbitraryType[T comparable](data []T) Value { ... }
```
don't save on allocations, and using reflection to determine the slice or map element types does have some benefit especially for slices but still has a high number of allocations for large maps. You can see an implementation of this change using reflection [here](https://github.com/dyolcekaj/launchdarkly-go-sdk-common/tree/arbitrary-collection-copies)


Here are benchmarks from my machine showing the improvement for these specific use cases. Command for all is 
`go test -benchmem '-run=^$$' -bench="CollectionCopy*" ./ldvalue`

Before:
```
BenchmarkCollectionCopyMapStringSmall-16              	  197137	      5597 ns/op	    4730 B/op	      47 allocs/op
BenchmarkCollectionCopyMapStringLarge-16              	    1776	    632766 ns/op	  676664 B/op	    4043 allocs/op
BenchmarkCollectionCopySliceStringSmall-16            	  415045	      2731 ns/op	    3931 B/op	      19 allocs/op
BenchmarkCollectionCopySliceStringMedium-16           	   57158	     20780 ns/op	   35357 B/op	     112 allocs/op
BenchmarkCollectionCopySliceStringLarge-16            	    6002	    186840 ns/op	  267965 B/op	    1016 allocs/op
BenchmarkCollectionCopySliceIntSmall-16               	  428552	      2633 ns/op	    3835 B/op	       9 allocs/op
BenchmarkCollectionCopySliceIntMedium-16              	   58148	     20332 ns/op	   34397 B/op	      12 allocs/op
BenchmarkCollectionCopySliceIntLarge-16               	    6182	    180290 ns/op	  260010 B/op	      15 allocs/op
```

After: 
```
BenchmarkCollectionCopyMapStringSmall-16       	 1568584	       769.4 ns/op	    2117 B/op	       2 allocs/op
BenchmarkCollectionCopyMapStringLarge-16       	   15642	     76328 ns/op	  254033 B/op	       3 allocs/op
BenchmarkCollectionCopySliceStringSmall-16     	 5143736	       226.0 ns/op	    1048 B/op	       2 allocs/op
BenchmarkCollectionCopySliceStringMedium-16    	  825129	      1439 ns/op	    9752 B/op	       2 allocs/op
BenchmarkCollectionCopySliceStringLarge-16     	   78724	     15250 ns/op	   98328 B/op	       2 allocs/op
BenchmarkCollectionCopySliceIntSmall-16        	 5327779	       224.1 ns/op	    1048 B/op	       2 allocs/op
BenchmarkCollectionCopySliceIntMedium-16       	  832033	      1419 ns/op	    9752 B/op	       2 allocs/op
BenchmarkCollectionCopySliceIntLarge-16        	   86389	     13898 ns/op	   98328 B/op	       2 allocs/op
```

Reflection based benchmark 
```
BenchmarkReflectCopyMapStringSmall-16              	  516852	      2229 ns/op	    2678 B/op	      23 allocs/op
BenchmarkReflectCopyMapStringLarge-16              	    5341	    197526 ns/op	  310622 B/op	    2004 allocs/op
BenchmarkReflectCopySliceStringSmall-16            	 2635124	       447.3 ns/op	    1048 B/op	       2 allocs/op
BenchmarkReflectCopySliceStringMedium-16           	  346424	      3233 ns/op	    9752 B/op	       2 allocs/op
BenchmarkReflectCopySliceStringLarge-16            	   38649	     31042 ns/op	   98329 B/op	       2 allocs/op
BenchmarkReflectCopySliceIntSmall-16               	 2634298	       448.7 ns/op	    1048 B/op	       2 allocs/op
BenchmarkReflectCopySliceIntMedium-16              	  340862	      3293 ns/op	    9752 B/op	       2 allocs/op
BenchmarkReflectCopySliceIntLarge-16               	   39921	     30468 ns/op	   98328 B/op	       2 allocs/op
```

Benchstat
```
goos: darwin
goarch: amd64
pkg: github.com/launchdarkly/go-sdk-common/v3/ldvalue
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
                                │ original.txt  │              updated.txt              │
                                │    sec/op     │    sec/op     vs base                 │
CollectionCopyMapStringSmall-16       5.534µ ± ∞ ¹   2.103µ ± ∞ ¹        ~ (p=1.000 n=1) ²
CollectionCopyMapStringLarge-16       680.4µ ± ∞ ¹   193.5µ ± ∞ ¹        ~ (p=1.000 n=1) ²
CollectionCopySliceStringSmall-16    2818.0n ± ∞ ¹   431.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
CollectionCopySliceStringMedium-16   20.874µ ± ∞ ¹   3.299µ ± ∞ ¹        ~ (p=1.000 n=1) ²
CollectionCopySliceStringLarge-16    188.00µ ± ∞ ¹   30.97µ ± ∞ ¹        ~ (p=1.000 n=1) ²
CollectionCopySliceIntSmall-16       2672.0n ± ∞ ¹   441.5n ± ∞ ¹        ~ (p=1.000 n=1) ²
CollectionCopySliceIntMedium-16      20.542µ ± ∞ ¹   3.196µ ± ∞ ¹        ~ (p=1.000 n=1) ²
CollectionCopySliceIntLarge-16       181.99µ ± ∞ ¹   30.73µ ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                            28.34µ         5.449µ        -80.77%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                │  original.txt  │              updated.txt               │
                                │      B/op      │     B/op       vs base                 │
CollectionCopyMapStringSmall-16       4.618Ki ± ∞ ¹   2.615Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
CollectionCopyMapStringLarge-16       661.2Ki ± ∞ ¹   303.3Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
CollectionCopySliceStringSmall-16     3.839Ki ± ∞ ¹   1.023Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
CollectionCopySliceStringMedium-16   34.526Ki ± ∞ ¹   9.523Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
CollectionCopySliceStringLarge-16    262.07Ki ± ∞ ¹   96.02Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
CollectionCopySliceIntSmall-16        3.745Ki ± ∞ ¹   1.023Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
CollectionCopySliceIntMedium-16      33.590Ki ± ∞ ¹   9.523Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
CollectionCopySliceIntLarge-16       253.86Ki ± ∞ ¹   96.02Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                            36.83Ki         12.74Ki        -65.41%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                │  original.txt  │              updated.txt              │
                                │   allocs/op    │  allocs/op    vs base                 │
CollectionCopyMapStringSmall-16         47.00 ± ∞ ¹    23.00 ± ∞ ¹        ~ (p=1.000 n=1) ²
CollectionCopyMapStringLarge-16        4.043k ± ∞ ¹   2.004k ± ∞ ¹        ~ (p=1.000 n=1) ²
CollectionCopySliceStringSmall-16      19.000 ± ∞ ¹    2.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
CollectionCopySliceStringMedium-16    112.000 ± ∞ ¹    2.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
CollectionCopySliceStringLarge-16    1016.000 ± ∞ ¹    2.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
CollectionCopySliceIntSmall-16          9.000 ± ∞ ¹    2.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
CollectionCopySliceIntMedium-16        12.000 ± ∞ ¹    2.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
CollectionCopySliceIntLarge-16         15.000 ± ∞ ¹    2.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                              71.27          6.438        -90.97%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05
```

Regardless of your decision to accept this change, I appreciate your time. 

