### PR TITLE
feat: Create generic Option type inspired by Rust

### DIFF
--- a/option.go
+++ b/option.go
@@ -1,0 +1,59 @@
+package ldcommon
+
+// Option represents an optional value: every Option is either Some and contains a value, or None, and does not.
+type Option[T any] struct {
+	value     T
+	isDefined bool
+}
+
+// Some creates an Option with a value.
+func Some[T any](value T) Option[T] {
+	return Option[T]{value: value, isDefined: true}
+}
+
+// None creates an Option with no value.
+func None[T any]() Option[T] {
+	return Option[T]{isDefined: false}
+}
+
+// IsSome returns true if the Option contains a value.
+func (o Option[T]) IsSome() bool {
+	return o.isDefined
+}
+
+// IsNone returns true if the Option does not contain a value.
+func (o Option[T]) IsNone() bool {
+	return !o.isDefined
+}
+
+// Unwrap returns the contained value, or panics if the Option is None.
+func (o Option[T]) Unwrap() T {
+	if o.IsNone() {
+		panic("called Unwrap on a None Option")
+	}
+	return o.value
+}
+
+// UnwrapOr returns the contained value, or a provided default if the Option is None.
+func (o Option[T]) UnwrapOr(defaultValue T) T {
+	if o.IsNone() {
+		return defaultValue
+	}
+	return o.value
+}
+
+// Map applies a function to the contained value (if any), and returns a new Option containing the result.
+func Map[T any, U any](o Option[T], f func(T) U) Option[U] {
+	if o.IsNone() {
+		return None[U]()
+	}
+	return Some(f(o.value))
+}
+
+// OrElse returns the Option if it contains a value, or calls the provided function and returns its result otherwise.
+func (o Option[T]) OrElse(f func() Option[T]) Option[T] {
+	if o.IsSome() {
+		return o
+	}
+	return f()
+}

--- a/option.go
+++ b/option.go
@@ -42,6 +42,14 @@ func (o Option[T]) UnwrapOr(defaultValue T) T {
 	return o.value
 }
 
+// AsPtr returns a pointer to the contained value, or nil if the Option is None.
+func (o Option[T]) AsPtr() *T {
+	if o.IsNone() {
+		return nil
+	}
+	return &o.value
+}
+
 // Map applies a function to the contained value (if any), and returns a new Option containing the result.
 func Map[T any, U any](o Option[T], f func(T) U) Option[U] {
 	if o.IsNone() {

--- a/option_test.go
+++ b/option_test.go
@@ -41,6 +41,18 @@ func TestOptionMap(t *testing.T) {
 	assert.Equal(t, "Value: 42", mappedSome.Unwrap())
 }
 
+func TestOptionAsPtr(t *testing.T) {
+	someOpt := Some(42)
+	noneOpt := None[int]()
+
+	somePtr := someOpt.AsPtr()
+	nonePtr := noneOpt.AsPtr()
+
+	assert.NotNil(t, somePtr)
+	assert.Equal(t, 42, *somePtr)
+	assert.Nil(t, nonePtr)
+}
+
 func TestOptionOrElse(t *testing.T) {
 	someOpt := Some(42)
 	noneOpt := None[int]()

--- a/option_test.go
+++ b/option_test.go
@@ -1,0 +1,53 @@
+package ldcommon
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOptionSome(t *testing.T) {
+	opt := Some(42)
+	assert.True(t, opt.IsSome())
+	assert.False(t, opt.IsNone())
+	assert.Equal(t, 42, opt.Unwrap())
+}
+
+func TestOptionNone(t *testing.T) {
+	opt := None[int]()
+	assert.False(t, opt.IsSome())
+	assert.True(t, opt.IsNone())
+	assert.Panics(t, func() { opt.Unwrap() })
+}
+
+func TestOptionUnwrapOr(t *testing.T) {
+	someOpt := Some(42)
+	noneOpt := None[int]()
+
+	assert.Equal(t, 42, someOpt.UnwrapOr(100))
+	assert.Equal(t, 100, noneOpt.UnwrapOr(100))
+}
+
+func TestOptionMap(t *testing.T) {
+	someOpt := Some(42)
+	noneOpt := None[int]()
+
+	mappedSome := Map(someOpt, func(x int) string { return "Value: " + fmt.Sprint(x) })
+	mappedNone := Map(noneOpt, func(x int) string { return "Value: " + fmt.Sprint(x) })
+
+	assert.True(t, mappedSome.IsSome())
+	assert.False(t, mappedNone.IsSome())
+	assert.Equal(t, "Value: 42", mappedSome.Unwrap())
+}
+
+func TestOptionOrElse(t *testing.T) {
+	someOpt := Some(42)
+	noneOpt := None[int]()
+
+	orElseSome := someOpt.OrElse(func() Option[int] { return Some(100) })
+	orElseNone := noneOpt.OrElse(func() Option[int] { return Some(100) })
+
+	assert.Equal(t, 42, orElseSome.Unwrap())
+	assert.Equal(t, 100, orElseNone.Unwrap())
+}


### PR DESCRIPTION
This SDK already supports ldvalue.Optional(Int|Boolean|String) types.
However, this exposes a much more generic type that can be used without
those restrictions.
