### PR TITLE
chore: remove golang.org/x/exp as depenency

### DIFF
--- a/.github/variables/go-versions.env
+++ b/.github/variables/go-versions.env
@@ -1,3 +1,3 @@
 latest=1.24
-penultimate=1.22
-min=1.18
+penultimate=1.23
+min=1.23

--- a/.github/variables/go-versions.env
+++ b/.github/variables/go-versions.env
@@ -1,3 +1,3 @@
-latest=1.23
+latest=1.24
 penultimate=1.22
 min=1.18

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-
-GOLANGCI_LINT_VERSION=v1.60.1
+GOLANGCI_LINT_VERSION=v1.64.5
 
 LINTER=./bin/golangci-lint
 LINTER_VERSION_FILE=./bin/.golangci-lint-version-$(GOLANGCI_LINT_VERSION)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Applications using the LaunchDarkly Go SDK will generally use the `ldcontext` su
 
 ## Supported Go versions
 
-This version of the project requires a Go version of 1.18 or higher.
+This version of the project requires a Go version of 1.24 or higher.
 
 ## Integration with easyjson
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Applications using the LaunchDarkly Go SDK will generally use the `ldcontext` su
 
 ## Supported Go versions
 
-This version of the project requires a Go version of 1.24 or higher.
+This version of the project requires a Go version of 1.23 or higher.
 
 ## Integration with easyjson
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/launchdarkly/go-sdk-common/v3
 
-go 1.24
+go 1.23
 
 require (
 	github.com/launchdarkly/go-jsonstream/v3 v3.0.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/launchdarkly/go-test-helpers/v3 v3.0.1
 	github.com/mailru/easyjson v0.7.6
 	github.com/stretchr/testify v1.7.0
-	golang.org/x/exp v0.0.0-20220823124025-807a23277127
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/launchdarkly/go-sdk-common/v3
 
-go 1.18
+go 1.24
 
 require (
 	github.com/launchdarkly/go-jsonstream/v3 v3.0.0

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-golang.org/x/exp v0.0.0-20220823124025-807a23277127 h1:S4NrSKDfihhl3+4jSTgwoIevKxX9p7Iv9x++OEIptDo=
-golang.org/x/exp v0.0.0-20220823124025-807a23277127/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/ldcontext/builder_multi.go
+++ b/ldcontext/builder_multi.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/launchdarkly/go-sdk-common/v3/lderrors"
 
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 const defaultMultiBuilderCapacity = 3 // arbitrary value based on presumed likely use cases

--- a/ldcontext/builder_simple.go
+++ b/ldcontext/builder_simple.go
@@ -8,7 +8,7 @@ import (
 	"github.com/launchdarkly/go-sdk-common/v3/lderrors"
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
 
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 // Builder is a mutable object that uses the builder pattern to specify properties for a Context.

--- a/ldcontext/context.go
+++ b/ldcontext/context.go
@@ -8,7 +8,7 @@ import (
 	"github.com/launchdarkly/go-sdk-common/v3/lderrors"
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
 
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 // Context is a collection of attributes that can be referenced in flag evaluations and analytics events.

--- a/lderrors/context_errors.go
+++ b/lderrors/context_errors.go
@@ -2,10 +2,10 @@ package lderrors
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
-	"golang.org/x/exp/maps"
+	"maps"
 )
 
 const (
@@ -83,8 +83,8 @@ func (e ErrContextKindMultiDuplicates) Error() string    { return msgContextKind
 func (e ErrContextKindInvalidChars) Error() string       { return msgContextKindInvalidChars }
 
 func (e ErrContextPerKindErrors) Error() string {
-	sortedKeys := maps.Keys(e.Errors)
-	sort.Strings(sortedKeys)
+	sortedKeys := slices.Sorted(maps.Keys(e.Errors))
+
 	messages := make([]string, 0, len(e.Errors))
 	for _, kind := range sortedKeys {
 		messages = append(messages, fmt.Sprintf("(%s) %s", kind, e.Errors[kind]))

--- a/ldtime/unix_millis.go
+++ b/ldtime/unix_millis.go
@@ -8,7 +8,7 @@ type UnixMillisecondTime uint64
 // UnixMillisFromTime converts a Time value into UnixMillisecondTime.
 func UnixMillisFromTime(t time.Time) UnixMillisecondTime {
 	ms := time.Duration(t.UnixNano()) / time.Millisecond
-	return UnixMillisecondTime(ms)
+	return UnixMillisecondTime(ms) //nolint:gosec
 }
 
 // UnixMillisNow returns the current date/time as a UnixMillisecondTime.

--- a/ldvalue/value_array.go
+++ b/ldvalue/value_array.go
@@ -1,7 +1,7 @@
 package ldvalue
 
 import (
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 // we reuse this for all non-nil zero-length ValueArray instances

--- a/ldvalue/value_base.go
+++ b/ldvalue/value_base.go
@@ -3,7 +3,7 @@ package ldvalue
 import (
 	"encoding/json"
 
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 // Value represents any of the data types supported by JSON, all of which can be used for a LaunchDarkly

--- a/ldvalue/value_map.go
+++ b/ldvalue/value_map.go
@@ -1,7 +1,7 @@
 package ldvalue
 
 import (
-	"golang.org/x/exp/maps"
+	"maps"
 )
 
 // we reuse this for all non-nil zero-length ValueMap instances


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions


Removed `golang.org/x/exp` as a dependency, and replaced it with standard library functions. Bumped go version to 1.24.

BEGIN_COMMIT_OVERRIDE
chore: Remove golang.org/x/exp as dependency
fix: Bump minimum go version to 1.24
END_COMMIT_OVERRIDE