### PR TITLE
chore: Remove duplicate version from "all"

### DIFF
--- a/.github/workflows/go-versions.yml
+++ b/.github/workflows/go-versions.yml
@@ -45,8 +45,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set Go Versions
         id: set-env
-        run:  cat ./.github/variables/go-versions.env > $GITHUB_OUTPUT
+        run: cat ./.github/variables/go-versions.env > $GITHUB_OUTPUT
       - name: Set Go Version Matrices
         id: set-matrix
         run: |
-          echo "all=[\"${{ steps.set-env.outputs.latest }}\",\"${{ steps.set-env.outputs.penultimate }}\",\"${{ steps.set-env.outputs.min }}\"]" >> $GITHUB_OUTPUT
+          if [ "${{ steps.set-env.outputs.penultimate }}" == "${{ steps.set-env.outputs.min }}" ]; then
+            echo "all=[\"${{ steps.set-env.outputs.latest }}\",\"${{ steps.set-env.outputs.penultimate }}\"]" >> $GITHUB_OUTPUT
+          else
+            echo "all=[\"${{ steps.set-env.outputs.latest }}\",\"${{ steps.set-env.outputs.penultimate }}\",\"${{ steps.set-env.outputs.min }}\"]" >> $GITHUB_OUTPUT
+          fi


### PR DESCRIPTION
This action determines which versions of go we are supporting, including
a latest, penultimate, and a minimum version. When the minimum and
penultimate are the same version, we would have duplicate entries.

This would lead to multiple runs of the same sets of tests (which would
be fine), but failed when the test results were uploaded, due to naming
collisions.
