### PR TITLE
Add ldcontext.NewBuilderWithCapacity constructor

### DIFF
--- a/internal/sharedtest/custom_attributes.go
+++ b/internal/sharedtest/custom_attributes.go
@@ -7,8 +7,9 @@ import (
 )
 
 const (
-	SmallNumberOfCustomAttributes = 2  //nolint:revive
-	LargeNumberOfCustomAttributes = 20 //nolint:revive
+	SmallNumberOfCustomAttributes  = 2  //nolint:revive
+	MiddleNumberOfCustomAttributes = 10 //nolint:revive
+	LargeNumberOfCustomAttributes  = 50
 )
 
 type NameAndLDValue struct { //nolint:revive

--- a/ldcontext/builder_benchmark_test.go
+++ b/ldcontext/builder_benchmark_test.go
@@ -31,12 +31,36 @@ func BenchmarkBuildWithNoCustomAttrs(b *testing.B) {
 }
 
 func BenchmarkBuildWithCustomAttributes(b *testing.B) {
-	for _, n := range []int{sharedtest.SmallNumberOfCustomAttributes, sharedtest.LargeNumberOfCustomAttributes} {
+	for _, n := range []int{
+		sharedtest.SmallNumberOfCustomAttributes,
+		sharedtest.MiddleNumberOfCustomAttributes,
+		sharedtest.LargeNumberOfCustomAttributes,
+	} {
 		b.Run(fmt.Sprintf("with %d attributes", n), func(b *testing.B) {
 			attrs := sharedtest.MakeCustomAttributeNamesAndValues(n)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				builder := NewBuilder("key")
+				for _, a := range attrs {
+					builder.SetValue(a.Name, a.Value)
+				}
+				benchmarkContext = builder.Build()
+			}
+		})
+	}
+}
+
+func BenchmarkBuildWithCustomAttributesWithCapacity(b *testing.B) {
+	for _, n := range []int{
+		sharedtest.SmallNumberOfCustomAttributes,
+		sharedtest.MiddleNumberOfCustomAttributes,
+		sharedtest.LargeNumberOfCustomAttributes,
+	} {
+		b.Run(fmt.Sprintf("with %d attributes", n), func(b *testing.B) {
+			attrs := sharedtest.MakeCustomAttributeNamesAndValues(n)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				builder := NewBuilderWithCapacity("key", n)
 				for _, a := range attrs {
 					builder.SetValue(a.Name, a.Value)
 				}

--- a/ldcontext/builder_simple.go
+++ b/ldcontext/builder_simple.go
@@ -126,6 +126,14 @@ func NewBuilder(key string) *Builder {
 	return b.Key(key)
 }
 
+// NewBuilderWithCapacity extends the behavior of NewBuilder to pre-allocate capacity for attributes.
+func NewBuilderWithCapacity(key string, capacity int) *Builder {
+	b := &Builder{
+		attributes: *ldvalue.ValueMapBuildWithCapacity(capacity),
+	}
+	return b.Key(key)
+}
+
 // NewBuilderFromContext creates a Builder whose properties are the same as an existing
 // single context.
 //


### PR DESCRIPTION
**Requirements**

- [X] I have added test coverage for new or changed functionality
- [X] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

To align experimentation across teams and deployments, we've wrapped your SDK in a library that we distribute across the org.  This library abstracts away and standardizes most attributes that anyone would want to run an experiment against, and in doing so adds many attributes by default to each `ldcontext.Context` for evaluations. 

When profiling a few deployments for unrelated reasons, we noted that allocations in `*ValueMapBuilder.Set(...)` were usually at least visible in profiling although not egregiously so. Because we know the number of attributes we can define a capacity to pre-allocate and this would be a moderate reduction in allocations across a majority of our deployments. 

**Describe the solution you've provided**

Add a new constructor `ldcontext.NewBuilderWithCapacity(key string, capacity int)` that utilizes `ldvalue.ValueMapBuilderWithCapacity(capacity int)`. 

**Describe alternatives you've considered**

I got cute with functional options for a second but I reeled it in. 

**Additional context**

Benchmarks 

```
✗ go test -run='^$' -bench=BenchmarkBuildWithCustomAttributes -benchmem
goos: darwin
goarch: amd64
pkg: github.com/launchdarkly/go-sdk-common/v3/ldcontext
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkBuildWithCustomAttributes/with_2_attributes-16         	 4110615	       279.1 ns/op	    1072 B/op	       2 allocs/op
BenchmarkBuildWithCustomAttributes/with_10_attributes-16        	 1000000	      1040 ns/op	    3141 B/op	       3 allocs/op
BenchmarkBuildWithCustomAttributes/with_50_attributes-16        	  193011	      5905 ns/op	   17782 B/op	       7 allocs/op
BenchmarkBuildWithCustomAttributesWithCapacity/with_2_attributes-16         	 4233372	       277.0 ns/op	    1072 B/op	       2 allocs/op
BenchmarkBuildWithCustomAttributesWithCapacity/with_10_attributes-16        	 1565258	       748.0 ns/op	    2117 B/op	       2 allocs/op
BenchmarkBuildWithCustomAttributesWithCapacity/with_50_attributes-16        	  346684	      3492 ns/op	    9600 B/op	       3 allocs/op
PASS
ok  	github.com/launchdarkly/go-sdk-common/v3/ldcontext	9.636s
➜
```
