### PR TITLE
chore: Update gosec workflow action references to pinned SHAs

### DIFF
--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           args: --exclude-generated=true --severity=medium --concurrency=1 --fmt json --out=gosec-results.json --stdout --verbose=text --no-fail ./...
       - name: Configure AWS Credentials
+        if: github.event_name != 'pull_request'
         # https://github.com/aws-actions/configure-aws-credentials/releases/tag/v6.0.0
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
         with:
@@ -40,5 +41,6 @@ jobs:
           role-to-assume: ${{ secrets.ORG_SECURITY_GHA_ROLE_ARN }}
           aws-region: us-east-1
       - name: Upload scan results to S3
+        if: github.event_name != 'pull_request'
         run: |
           aws s3 cp ./gosec-results.json "s3://launchdarkly-org-security-inventory/scan-results/gosec/${{ steps.date.outputs.date }}/$GITHUB_REPOSITORY.json"

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - devin/1773939059-fix-gosec-workflow-action-shas
 
 permissions:
   id-token: write

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -18,16 +18,19 @@ jobs:
     steps:
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y/%m/%d')"
+        run: echo "date=$(date +'%Y/%m/%d')" >> "$GITHUB_OUTPUT"
       - name: Checkout Source
-        uses: actions/checkout@v3
+        # https://github.com/actions/checkout/releases/tag/v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@2.14.0
+        # https://github.com/securego/gosec/releases/tag/v2.25.0
+        uses: securego/gosec@223e19b8856e00f02cc67804499a83f77e208f3c
         timeout-minutes: 5
         with:
           args: --exclude-generated=true --severity=medium --concurrency=1 --fmt json --out=gosec-results.json --stdout --verbose=text --no-fail ./...
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        # https://github.com/aws-actions/configure-aws-credentials/releases/tag/v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a
         with:
           audience: https://github.com/launchdarkly
           role-to-assume: ${{ secrets.ORG_SECURITY_GHA_ROLE_ARN }}

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 permissions:
   id-token: write

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - devin/1773939059-fix-gosec-workflow-action-shas
 
 permissions:
   id-token: write

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -1,5 +1,6 @@
 name: Gosec
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 8 * * *'
   push:

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -22,8 +22,8 @@ jobs:
         id: date
         run: echo "date=$(date +'%Y/%m/%d')" >> "$GITHUB_OUTPUT"
       - name: Checkout Source
-        # https://github.com/actions/checkout/releases/tag/v4.3.1
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # https://github.com/actions/checkout/releases/tag/v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Run Gosec Security Scanner
         # https://github.com/securego/gosec/releases/tag/v2.25.0
         uses: securego/gosec@223e19b8856e00f02cc67804499a83f77e208f3c
@@ -31,8 +31,8 @@ jobs:
         with:
           args: --exclude-generated=true --severity=medium --concurrency=1 --fmt json --out=gosec-results.json --stdout --verbose=text --no-fail ./...
       - name: Configure AWS Credentials
-        # https://github.com/aws-actions/configure-aws-credentials/releases/tag/v4
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a
+        # https://github.com/aws-actions/configure-aws-credentials/releases/tag/v6.0.0
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
         with:
           audience: https://github.com/launchdarkly
           role-to-assume: ${{ secrets.ORG_SECURITY_GHA_ROLE_ARN }}


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/v3/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

The daily `Gosec` workflow has been failing since `securego/gosec@2.14.0` no longer resolves as a valid action reference:
```
Unable to resolve action `securego/gosec@2.14.0`, unable to find version `2.14.0`
```

**Describe the solution you've provided**

All action references in `gosec.yml` are updated to full commit SHAs with a comment linking to the corresponding release:

| Action | Old | New |
|--------|-----|-----|
| `actions/checkout` | `v3` | `v6.0.2` ([release](https://github.com/actions/checkout/releases/tag/v6.0.2)) |
| `securego/gosec` | `2.14.0` (broken) | `v2.25.0` ([release](https://github.com/securego/gosec/releases/tag/v2.25.0)) |
| `aws-actions/configure-aws-credentials` | `v1` | `v6.0.0` ([release](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v6.0.0)) |

Additional changes:
- Replaced the deprecated `::set-output` command with `$GITHUB_OUTPUT`.
- Added `workflow_dispatch` trigger to allow manual runs.
- Added `pull_request` trigger for the `main` branch so gosec runs on PRs.

**Describe alternatives you've considered**

Could pin to version tags (e.g. `securego/gosec@v2.25.0`) instead of SHAs, but SHA pinning is the recommended security practice for GitHub Actions.

**Additional context**

**✅ Validated on branch** — the Gosec workflow was triggered on this branch (via a temporary push trigger, since removed) and [passed successfully](https://github.com/launchdarkly/go-sdk-common/actions/runs/23306874047), including the gosec scan and AWS credentials / S3 upload steps.

**⚠️ Key items for reviewer:**
- **Verify SHAs match the linked releases** — each `uses:` line has a comment with the release URL for cross-referencing.
- **`aws-actions/configure-aws-credentials` v1 → v6** is a major version jump. The inputs used here (`audience`, `role-to-assume`, `aws-region`) worked in the branch validation run, but worth confirming this is the desired target version for the org.
- **`securego/gosec` v2.14.0 → v2.25.0** — CLI args were validated in the branch run. The `--no-fail` flag means scan findings won't break the job.
- **Node.js 24 compatibility** — `actions/checkout` and `aws-actions/configure-aws-credentials` were bumped to v6 specifically to avoid the Node.js 20 deprecation warning (Node.js 20 actions will be forced to Node.js 24 starting June 2, 2026).
- **New `pull_request` trigger** — gosec will now also run on PRs targeting `main`. The scan is quick (~5 min timeout) so impact on PR CI time should be minimal.

Link to Devin session: https://app.devin.ai/sessions/f07904a28c9048778d5b15d1d2c8eba5
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change, but it updates the `configure-aws-credentials` action to a new major version and adjusts when AWS/S3 upload steps run, which could affect artifact publishing.
> 
> **Overview**
> Updates the `Gosec` GitHub Actions workflow to run on `pull_request` to `main` and via `workflow_dispatch`, in addition to the existing schedule/push triggers.
> 
> Pins `actions/checkout`, `securego/gosec`, and `aws-actions/configure-aws-credentials` to specific commit SHAs (with release links), replaces deprecated `::set-output` with `$GITHUB_OUTPUT`, and skips AWS credential setup + S3 upload when running in PRs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d16ed4f235943d9fd99a3bee2366141f7f9f3afb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->