### PR TITLE
chore: add explicit permissions to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         with:


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

N/A — this is a CI-only change with no functional code impact.

**Related issues**

None — identified during an audit of `launchdarkly-sdk`-tagged repositories for missing release-please workflow permissions.

**Describe the solution you've provided**

Adds explicit `contents: write` and `pull-requests: write` permissions to the `release-please` job. Without these, the job relies on the repository's default `GITHUB_TOKEN` permissions, which may not grant write access. Release-please needs:

- `contents: write` — to create GitHub releases and push tags
- `pull-requests: write` — to create and update release PRs

**Describe alternatives you've considered**

Setting default permissions at the workflow level (`permissions:` at the top) was considered, but job-level permissions follow the principle of least privilege and avoid granting unnecessary access to other jobs in the workflow.

**Additional context**

This was identified as part of a bulk audit of all non-archived repos with the `launchdarkly-sdk` topic. The same fix is being applied across multiple repositories.

**Human review checklist**
- [ ] Confirm `contents: write` and `pull-requests: write` are the only permissions release-please needs in this repo
- [ ] Verify no other jobs in the workflow are unintentionally affected

Link to Devin session: https://app.devin.ai/sessions/a83b6e4f4fa14b96b859cfb50755a2c1
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that only adjusts GitHub Actions `GITHUB_TOKEN` permissions for the `release-please` job.
> 
> **Overview**
> Adds explicit job-level GitHub Actions permissions (`contents: write`, `pull-requests: write`) to the `release-please` workflow so the Release Please action can create/update release PRs and tags/releases without relying on repository default token permissions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd238a4fcc6a313a3888eb51f9d362830d4b4683. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->